### PR TITLE
BUG: Ensure factory is registered once.

### DIFF
--- a/include/itkDCMTKTransformIO.h
+++ b/include/itkDCMTKTransformIO.h
@@ -18,6 +18,8 @@
 #ifndef __itkDCMTKTransformIO_h
 #define __itkDCMTKTransformIO_h
 
+#include "IOTransformDCMTKExport.h"
+
 #include "itkTransformIOBase.h"
 
 namespace itk
@@ -32,7 +34,7 @@ namespace itk
  * \ingroup IOTransformDCMTK
  */
 template< typename TInternalComputationValueType >
-class DCMTKTransformIO: public TransformIOBaseTemplate< TInternalComputationValueType >
+class IOTransformDCMTK_EXPORT DCMTKTransformIO: public TransformIOBaseTemplate< TInternalComputationValueType >
 {
 public:
   typedef DCMTKTransformIO                                         Self;
@@ -82,8 +84,6 @@ private:
 
 } // end namespace itk
 
-#ifndef ITK_MANUAL_INSTANTIATION
-#include "itkDCMTKTransformIO.hxx"
-#endif
+// Note: Explicit instantiation is done in itkDCMTKTransformIOInstantiation.cxx
 
 #endif // __itkDCMTKTransformIO_h

--- a/include/itkDCMTKTransformIOFactory.h
+++ b/include/itkDCMTKTransformIOFactory.h
@@ -18,6 +18,7 @@
 #ifndef __itkDCMTKTransformIOFactory_h
 #define __itkDCMTKTransformIOFactory_h
 
+#include "IOTransformDCMTKExport.h"
 
 #include "itkObjectFactoryBase.h"
 #include "itkTransformIOBase.h"
@@ -31,7 +32,7 @@ namespace itk
   *
   * \ingroup IOTransformDCMTK
   */
-class DCMTKTransformIOFactory:public ObjectFactoryBase
+class IOTransformDCMTK_EXPORT DCMTKTransformIOFactory:public ObjectFactoryBase
 {
 public:
   /** Standard class typedefs. */

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -2,6 +2,7 @@ set(DOCUMENTATION "This modules contains classes for the reading of transforms
 stored in DICOM files.")
 
 itk_module(IOTransformDCMTK
+  ENABLE_SHARED
   DEPENDS
     ITKIOTransformBase
     ITKDCMTK

--- a/src/itkDCMTKTransformIOFactory.cxx
+++ b/src/itkDCMTKTransformIOFactory.cxx
@@ -66,7 +66,7 @@ void DCMTKTransformIOFactory
 // DO NOT CALL DIRECTLY.
 static bool DCMTKTransformIOFactoryHasBeenRegistered;
 
-void DCMTKTransformIOFactoryRegister__Private(void)
+void IOTransformDCMTK_EXPORT DCMTKTransformIOFactoryRegister__Private(void)
 {
   if( ! DCMTKTransformIOFactoryHasBeenRegistered )
     {

--- a/src/itkDCMTKTransformIOInstantiation.cxx
+++ b/src/itkDCMTKTransformIOInstantiation.cxx
@@ -1,0 +1,28 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkDCMTKTransformIO.h"
+#include "itkDCMTKTransformIO.hxx"
+
+namespace itk
+{
+
+template class DCMTKTransformIO< double >;
+template class DCMTKTransformIO< float >;
+
+}  // end namespace itk


### PR DESCRIPTION
This commit updates CMakeLists.txt to ensure built library
is shared.

This commit introduces explicit instantiation where
templated factories are explicitly instantiated for "double" and "float"
types.

This will allow templated factories to be registered in one translation
unit and instantiated in an other.

See http://stackoverflow.com/questions/8024010/why-do-template-class-functions-have-to-be-declared-in-the-same-translation-unit

See ITK issue #3393
https://issues.itk.org/jira/browse/ITK-3393