### PR TITLE
COMP: Handle compiler not supporting "pragma diagnostic".

### DIFF
--- a/src/itkDCMTKTransformIO.cxx
+++ b/src/itkDCMTKTransformIO.cxx
@@ -23,16 +23,18 @@
 namespace itk
 {
 
-#if defined( __GNUC__ )
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_PUSH()
 #endif
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class IOTransformDCMTK_EXPORT DCMTKTransformIO< double >;
 template class IOTransformDCMTK_EXPORT DCMTKTransformIO< float >;
 
-#if defined( __GNUC__ )
-#pragma GCC diagnostic pop
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_POP()
+#else
+  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
 #endif
 
 }  // end namespace itk


### PR DESCRIPTION
This commit fixes warnings introduced in InsightSoftwareConsortium/ITK@eb2316a
(BUG: TransformIO: Implement explicit template instantiation using "extern".)
by handling version of GCC not supporting "pragma diagnostic"
preprocessor instruction.

It does so by using the new ITK macros introduced in ITK
commit (COMP: TransformIO: Handle compiler not supporting "pragma
diagnostic".)