### PR TITLE
BUG: Not enough arguments in EXERCISE_BASIC_OBJECT_METHODS (ITK-3459)

### DIFF
--- a/test/Docker/Dockerfile
+++ b/test/Docker/Dockerfile
@@ -32,8 +32,8 @@ RUN git clone https://github.com/Kitware/KWStyle.git && \
   ninja install && \
   cd .. && rm -rf KWStyle*
 
-# 2015-12-19
-ENV ITK_GIT_TAG 37166e7297c0002e2bf1ea0e936fde921bd28c19
+# 2016-10-12
+ENV ITK_GIT_TAG 6327e3b441cfb84baafae8133443a8c455c557db
 RUN git clone git://itk.org/ITK.git && \
   cd ITK && \
   git checkout ${ITK_GIT_TAG} && \

--- a/test/itkDCMTKTransformIOTest.cxx
+++ b/test/itkDCMTKTransformIOTest.cxx
@@ -36,7 +36,7 @@ int itkDCMTKTransformIOTest( int argc, char* argv[] )
   typedef float ScalarType;
 
   itk::DCMTKTransformIOFactory::Pointer dcmtkTransformIOFactory = itk::DCMTKTransformIOFactory::New();
-  EXERCISE_BASIC_OBJECT_METHODS( dcmtkTransformIOFactory, itk::DCMTKTransformIOFactory );
+  EXERCISE_BASIC_OBJECT_METHODS( dcmtkTransformIOFactory, DCMTKTransformIOFactory, ObjectFactoryBase );
   std::cout << std::endl;
   itk::ObjectFactoryBase::RegisterFactory( dcmtkTransformIOFactory );
 
@@ -46,7 +46,7 @@ int itkDCMTKTransformIOTest( int argc, char* argv[] )
 
   typedef itk::DCMTKTransformIO< ScalarType > TransformIOType;
   TransformIOType::Pointer transformIO = TransformIOType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( transformIO, TransformIOType );
+  EXERCISE_BASIC_OBJECT_METHODS( transformIO, DCMTKTransformIO, TransformIOBaseTemplate );
   transformReader->SetTransformIO( transformIO );
 
   TEST_EXPECT_TRUE( ! transformIO->CanWriteFile( transformFileName ) );


### PR DESCRIPTION
Correction of bug ITK-3459 [1]. EXERCISE_BASIC_OBJECT_METHODS now requires
3 arguments instead of 2. The new argument is the Superclass name.