### PR TITLE
COMP: Mark DCMTKTransformIO methods with override

### DIFF
--- a/include/itkDCMTKTransformIO.h
+++ b/include/itkDCMTKTransformIO.h
@@ -52,19 +52,19 @@ public:
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanReadFile(const char *);
+  bool CanReadFile(const char *) override;
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanWriteFile(const char *);
+  bool CanWriteFile(const char *) override;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read();
+  void Read() override;
 
   /** Writes the data to disk from the memory buffer provided. Make sure
    * that the IORegions has been set properly. The buffer is cast to a
    * pointer to the beginning of the image data. */
-  virtual void Write();
+  void Write() override;
 
   /** Set/Get the desired Frame of Reference UID, tag 0020|0052, for the
    * transform to be extracted. */


### PR DESCRIPTION
Addresses:

  /home/matt/src/ITKIOTransformDCMTK/include/itkDCMTKTransformIO.h:55:16: warning: 'CanReadFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool CanReadFile(const char *);
               ^
/home/matt/src/ITKIOTransformDCMTK/include/itkDCMTKTransformIO.h:114:56: note: in instantiation of template class 'itk::DCMTKTransformIO<double>' requested here
extern template class IOTransformDCMTK_EXPORT_EXPLICIT DCMTKTransformIO< double >;
                                                       ^
/home/matt/src/ITK/Modules/IO/TransformBase/include/itkTransformIOBase.h:95:16: note: overridden virtual function is here
  virtual bool CanReadFile(const char *) = 0;
               ^
In file included from /home/matt/src/ITKIOTransformDCMTK/src/itkDCMTKTransformIOFactory.cxx:20:
/home/matt/src/ITKIOTransformDCMTK/include/itkDCMTKTransformIO.h:59:16: warning: 'CanWriteFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool CanWriteFile(const char *);
               ^
/home/matt/src/ITK/Modules/IO/TransformBase/include/itkTransformIOBase.h:99:16: note: overridden virtual function is here
  virtual bool CanWriteFile(const char *)  = 0;
               ^
In file included from /home/matt/src/ITKIOTransformDCMTK/src/itkDCMTKTransformIOFactory.cxx:20:
/home/matt/src/ITKIOTransformDCMTK/include/itkDCMTKTransformIO.h:62:16: warning: 'Read' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual void Read();
               ^
/home/matt/src/ITK/Modules/IO/TransformBase/include/itkTransformIOBase.h:88:16: note: overridden virtual function is here
  virtual void Read() = 0;
               ^
In file included from /home/matt/src/ITKIOTransformDCMTK/src/itkDCMTKTransformIOFactory.cxx:20:
/home/matt/src/ITKIOTransformDCMTK/include/itkDCMTKTransformIO.h:67:16: warning: 'Write' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual void Write();