### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/include/itkDCMTKTransformIO.hxx
+++ b/include/itkDCMTKTransformIO.hxx
@@ -193,7 +193,7 @@ DCMTKTransformIO< TInternalComputationValueType >
                     itkExceptionMacro( "Could not get expected matrix entry." );
                     }
                   ++matrixEntryIndex;
-                  transformParameters[row * Dimension + col] = atof( matrixString.c_str() );
+                  transformParameters[row * Dimension + col] = std::stod( matrixString.c_str() );
                   }
                 result = currentMatrixSequenceItem->findAndGetOFString( DCM_FrameOfReferenceTransformationMatrix, matrixString, matrixEntryIndex );
                 if( ! result.good() )
@@ -201,7 +201,7 @@ DCMTKTransformIO< TInternalComputationValueType >
                   itkExceptionMacro( "Could not get expected matrix entry." );
                   }
                 ++matrixEntryIndex;
-                transformParameters[Dimension * Dimension + row] = atof( matrixString.c_str() );
+                transformParameters[Dimension * Dimension + row] = std::stod( matrixString.c_str() );
                 }
               affineTransform->SetParameters( transformParameters );
 


### PR DESCRIPTION
STYLE: Prefer error checked std::sto[id] over ato[if].

The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/
