### PR TITLE
DOC: Improve Python package information.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ setup(
     package_dir={'itk': 'itk'},
     download_url=r'https://github.com/InsightSoftwareConsortium/ITKIOTransformDCMTK',
     description=r'ITK classes to read DICOM spatial transforms',
-    long_description='ITKIOTransformDCMTK provides classes to read DICOM'
+    long_description='itk-iotransformdcmtk provides classes to read DICOM '
                      'Spatial Registration Object files into `itk::Transform`\'s.\n'
                      'Please refer to:\n'
-                     'M. McCormick, K. Wang, A. Lasso, G. Sharp, S. Pieper,'
-                     '“DICOM Spatial Transform IO in the Insight Toolkit.”,'
+                     'M. McCormick, K. Wang, A. Lasso, G. Sharp, S. Pieper, '
+                     '"DICOM Spatial Transform IO in the Insight Toolkit.", '
                      'Insight Journal, January-December 2014, http://hdl.handle.net/10380/3468.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Improve Python package information:
- Make the reference in the long description match the package name and
  not the ITK project name.
- Use white spaces to avoid words in two consecutive lines being
  concatenated.

Partially addresses:
https://github.com/InsightSoftwareConsortium/ITK/issues/326