### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkDCMTKTransformIO.hxx
+++ b/include/itkDCMTKTransformIO.hxx
@@ -18,7 +18,6 @@
 #ifndef itkDCMTKTransformIO_hxx
 #define itkDCMTKTransformIO_hxx
 
-#include "itkDCMTKTransformIO.h"
 
 #include "itkAffineTransform.h"
 #include "itkCompositeTransform.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

