### PR TITLE
COMP: Update CI best practices and Python 3.10+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,5 +14,5 @@ jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
-      itk-git-tag: 'v5.4.5'
+      itk-git-tag: '5eb11e272c'
       itk-cmake-options: '-DModule_ITKIODCMTK:BOOL=ON'

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,4 +14,5 @@ jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
+      itk-git-tag: 'v5.4.5'
       itk-cmake-options: '-DModule_ITKIODCMTK:BOOL=ON'

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
       itk-cmake-options: '-DModule_ITKIODCMTK:BOOL=ON'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]


### PR DESCRIPTION
Update CI infrastructure and Python version requirement.

<details>
<summary>Changes</summary>

1. **Python 3.10+** — bump `requires-python` from `>=3.9` to `>=3.10` (Python 3.9 EOL was Oct 2025)
2. **CI action v5.4.6** — update `ITKRemoteModuleBuildTestPackageAction` from `v5.4.2` to `v5.4.6` for latest runner support (macOS 15, Apple Silicon)
3. **Pin ITK v5.4.5** — the v5.4.6 action's default ITK commit has a DCMTK ExternalProject include path issue (`ijg12/include` exported but missing); pin to v5.4.5 release where DCMTK builds correctly

</details>

<!--
provenance: claude-code session 2026-04-14
root_cause: DCMTK ExternalProject exports ijg12/include in INTERFACE_INCLUDE_DIRECTORIES
  but the path doesn't exist when remote modules build against the ITK install
fix: pin itk-git-tag to v5.4.5 release
-->